### PR TITLE
Add HVSC collection search by title, author, or filename

### DIFF
--- a/2-build-hvsc-index.bat
+++ b/2-build-hvsc-index.bat
@@ -1,0 +1,28 @@
+@echo off
+setlocal
+
+echo ========================================
+echo SIDwinder HVSC Search Index Builder
+echo ========================================
+echo.
+echo Crawls hvsc.etv.cx and writes public\hvsc-index.json
+echo (title/author/released for every SID). This takes
+echo roughly 30-60 minutes on a full run.
+echo.
+
+where node >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: Node.js is not on PATH. Install from https://nodejs.org/ and retry.
+    exit /b 1
+)
+
+node tools\build-hvsc-index.js %*
+if errorlevel 1 (
+    echo.
+    echo Build failed.
+    exit /b 1
+)
+
+echo.
+echo Done. Commit public\hvsc-index.json to ship the updated search index.
+endlocal

--- a/public/hvsc-browser.html
+++ b/public/hvsc-browser.html
@@ -23,11 +23,16 @@
                 </button>
                 <input type="text" class="path-bar" id="pathBar" readonly>
             </div>
+            <div class="browser-search">
+                <i class="fas fa-search search-icon"></i>
+                <input type="text" class="search-bar" id="hvscSearchBar" placeholder="Search the whole collection by title, author, or filename..." autocomplete="off" spellcheck="false">
+                <button class="search-clear" id="hvscSearchClear" title="Clear search" style="display: none;">✕</button>
+            </div>
         </div>
-        
+
         <div class="browser-content">
             <div class="file-panel">
-                <div class="panel-header">Files & Directories</div>
+                <div class="panel-header" id="filePanelHeader">Files & Directories</div>
                 <div class="file-list" id="fileList">
                     <div class="file-list-loading"><div class="file-list-spinner"></div></div>
                 </div>

--- a/public/hvsc-browser.js
+++ b/public/hvsc-browser.js
@@ -12,10 +12,18 @@ window.hvscBrowser = (function () {
     // Add an initialization flag
     let hvscInitialized = false;
 
+    // Search state
+    let searchIndex = null;          // { entries: [{p,t,a,r}], ... } once loaded
+    let searchIndexPromise = null;   // in-flight load promise
+    let searchMode = false;          // true while showing search results
+    let searchDebounce = null;
+    const SEARCH_RESULT_LIMIT = 500;
+
     // Add an init function
     function initializeHVSC() {
         if (!hvscInitialized) {
             fetchDirectory('C64Music');
+            wireSearch();
             hvscInitialized = true;
         }
     }
@@ -39,6 +47,17 @@ window.hvscBrowser = (function () {
     }
 
     async function fetchDirectory(path) {
+        // Navigating into a directory clears any active search
+        if (searchMode) {
+            const input = document.getElementById('hvscSearchBar');
+            const clearBtn = document.getElementById('hvscSearchClear');
+            if (input) input.value = '';
+            if (clearBtn) clearBtn.style.display = 'none';
+            searchMode = false;
+            const header = document.getElementById('filePanelHeader');
+            if (header) header.textContent = 'Files & Directories';
+        }
+
         // Clean the path
         if (path.endsWith('/')) {
             path = path.slice(0, -1);
@@ -415,12 +434,183 @@ window.hvscBrowser = (function () {
         }
     });
 
+    function wireSearch() {
+        const input = document.getElementById('hvscSearchBar');
+        const clearBtn = document.getElementById('hvscSearchClear');
+        if (!input || input.dataset.wired === '1') return;
+        input.dataset.wired = '1';
+
+        input.addEventListener('input', () => {
+            const q = input.value.trim();
+            clearBtn.style.display = q ? 'inline-flex' : 'none';
+            if (searchDebounce) clearTimeout(searchDebounce);
+            searchDebounce = setTimeout(() => runSearch(q), 150);
+        });
+
+        clearBtn.addEventListener('click', () => {
+            input.value = '';
+            clearBtn.style.display = 'none';
+            if (searchDebounce) clearTimeout(searchDebounce);
+            exitSearchMode();
+        });
+    }
+
+    function loadSearchIndex() {
+        if (searchIndex) return Promise.resolve(searchIndex);
+        if (searchIndexPromise) return searchIndexPromise;
+        searchIndexPromise = fetch('hvsc-index.json')
+            .then((res) => {
+                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                return res.json();
+            })
+            .then((data) => {
+                searchIndex = data;
+                return data;
+            })
+            .catch((err) => {
+                searchIndexPromise = null;
+                throw err;
+            });
+        return searchIndexPromise;
+    }
+
+    function exitSearchMode() {
+        if (!searchMode) return;
+        searchMode = false;
+        const header = document.getElementById('filePanelHeader');
+        if (header) header.textContent = 'Files & Directories';
+        // Repaint the current directory so selection/state is consistent
+        renderEntries();
+        updateItemCount();
+    }
+
+    function renderEntries() {
+        const fileList = document.getElementById('fileList');
+        fileList.innerHTML = '';
+        entries.forEach(entry => {
+            const item = document.createElement('div');
+            item.className = 'file-item' + (entry.isDirectory ? ' directory' : '');
+            const icon = entry.isDirectory
+                ? '<i class="fas fa-folder"></i>'
+                : '<i class="fas fa-music"></i>';
+            item.innerHTML = `
+            <span class="file-icon">${icon}</span>
+            <span class="file-name">${escapeHtml(entry.name)}</span>
+        `;
+            item.onclick = () => handleItemClick(entry);
+            item.ondblclick = () => handleItemDoubleClick(entry);
+            fileList.appendChild(item);
+        });
+    }
+
+    function updateItemCount() {
+        const sidCount = entries.filter(e => !e.isDirectory).length;
+        const dirCount = entries.filter(e => e.isDirectory).length;
+        let countText;
+        if (sidCount > 0 && dirCount > 0) countText = `${sidCount} SID files, ${dirCount} folders`;
+        else if (sidCount > 0) countText = `${sidCount} SID file${sidCount !== 1 ? 's' : ''}`;
+        else if (dirCount > 0) countText = `${dirCount} folder${dirCount !== 1 ? 's' : ''}`;
+        else countText = 'Empty folder';
+        document.getElementById('itemCount').textContent = countText;
+    }
+
+    async function runSearch(query) {
+        if (!query) {
+            exitSearchMode();
+            return;
+        }
+
+        searchMode = true;
+        currentSelection = null;
+        const fileList = document.getElementById('fileList');
+        const header = document.getElementById('filePanelHeader');
+        if (header) header.textContent = 'Search Results';
+
+        fileList.innerHTML = '<div class="file-list-loading"><div class="file-list-spinner"></div></div>';
+
+        let index;
+        try {
+            index = await loadSearchIndex();
+        } catch (err) {
+            fileList.innerHTML =
+                '<div class="error-message">Search index not available yet. '
+                + 'Browse by folder, or ask the site maintainer to run '
+                + '<code>node tools/build-hvsc-index.js</code>.</div>';
+            document.getElementById('itemCount').textContent = 'Search unavailable';
+            return;
+        }
+
+        // Only render the latest query's results (guards against out-of-order fetches)
+        const currentInput = document.getElementById('hvscSearchBar').value.trim();
+        if (currentInput !== query) return;
+
+        const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+        const matches = [];
+        const all = index.entries;
+        const limit = SEARCH_RESULT_LIMIT;
+
+        for (let i = 0; i < all.length; i++) {
+            const e = all[i];
+            const hay = ((e.t || '') + '\x00' + (e.a || '') + '\x00' + (e.p || '')).toLowerCase();
+            let ok = true;
+            for (let j = 0; j < terms.length; j++) {
+                if (hay.indexOf(terms[j]) === -1) { ok = false; break; }
+            }
+            if (ok) {
+                matches.push(e);
+                if (matches.length >= limit) break;
+            }
+        }
+
+        renderSearchResults(matches, limit);
+        const shownPlural = matches.length === 1 ? 'match' : 'matches';
+        let countText = `${matches.length} ${shownPlural}`;
+        if (matches.length >= limit) countText += ` (first ${limit} shown)`;
+        document.getElementById('itemCount').textContent = countText;
+    }
+
+    function renderSearchResults(results, limit) {
+        const fileList = document.getElementById('fileList');
+        fileList.innerHTML = '';
+
+        if (results.length === 0) {
+            fileList.innerHTML = '<div class="search-empty">No matching SIDs found.</div>';
+            return;
+        }
+
+        const frag = document.createDocumentFragment();
+        results.forEach(r => {
+            const fileName = r.p.split('/').pop();
+            const folder = r.p.substring(0, r.p.length - fileName.length - 1);
+            const titleLine = r.t || fileName;
+            const authorLine = r.a || '';
+
+            const item = document.createElement('div');
+            item.className = 'file-item search-result';
+            item.innerHTML = `
+            <span class="file-icon"><i class="fas fa-music"></i></span>
+            <span class="search-result-text">
+                <span class="search-result-title">${escapeHtml(titleLine)}</span>
+                ${authorLine ? `<span class="search-result-author">${escapeHtml(authorLine)}</span>` : ''}
+                <span class="search-result-path">${escapeHtml(folder)}</span>
+            </span>
+        `;
+
+            const entry = { name: fileName, path: r.p, isDirectory: false, _searchMeta: r };
+            item.onclick = () => handleItemClick(entry);
+            item.ondblclick = () => handleItemDoubleClick(entry);
+            frag.appendChild(item);
+        });
+        fileList.appendChild(frag);
+    }
+
     // Public API
     return {
         navigateUp: navigateUp,
         navigateHome: navigateHome,
         fetchDirectory: fetchDirectory,
         stopPreview: stopPreview,
-        downloadSID: downloadSID
+        downloadSID: downloadSID,
+        initializeHVSC: initializeHVSC
     };
 })();

--- a/public/index.html
+++ b/public/index.html
@@ -948,11 +948,16 @@
                             </button>
                             <input type="text" class="path-bar" id="pathBar" readonly>
                         </div>
+                        <div class="browser-search">
+                            <i class="fas fa-search search-icon"></i>
+                            <input type="text" class="search-bar" id="hvscSearchBar" placeholder="Search the whole collection by title, author, or filename..." autocomplete="off" spellcheck="false">
+                            <button class="search-clear" id="hvscSearchClear" title="Clear search" style="display: none;">✕</button>
+                        </div>
                     </div>
 
                     <div class="browser-content">
                         <div class="file-panel">
-                            <div class="panel-header">Files & Directories</div>
+                            <div class="panel-header" id="filePanelHeader">Files & Directories</div>
                             <div class="file-list" id="fileList">
                                 <div class="file-list-loading"><div class="file-list-spinner"></div></div>
                             </div>

--- a/public/styles-deferred.css
+++ b/public/styles-deferred.css
@@ -1209,6 +1209,140 @@
     font-size: 12px;
 }
 
+.browser-search {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 10px;
+    position: relative;
+}
+
+.browser-search .search-icon {
+    position: absolute;
+    left: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--text-muted);
+    font-size: 12px;
+    pointer-events: none;
+}
+
+.search-bar {
+    flex: 1;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    padding: 7px 34px 7px 32px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    font-size: 13px;
+    transition: border-color var(--transition-fast);
+}
+
+.search-bar:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.search-bar::placeholder {
+    color: var(--text-muted);
+}
+
+.search-clear {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: transparent;
+    color: var(--text-muted);
+    border: none;
+    cursor: pointer;
+    font-size: 13px;
+    width: 22px;
+    height: 22px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    transition: all var(--transition-fast);
+}
+
+.search-clear:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+}
+
+.file-item.search-result {
+    align-items: flex-start;
+    padding: 8px 12px;
+}
+
+.search-result-text {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.search-result-title {
+    color: var(--text-primary);
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.search-result-author {
+    color: var(--text-secondary);
+    font-size: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.search-result-path {
+    color: var(--text-muted);
+    font-size: 11px;
+    font-family: var(--font-mono);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.file-item.search-result.selected .search-result-title,
+.file-item.search-result.selected .search-result-author {
+    color: var(--text-primary);
+}
+
+.search-empty {
+    padding: 40px 20px;
+    text-align: center;
+    color: var(--text-muted);
+    font-style: italic;
+    font-size: 13px;
+}
+
+.file-list .error-message {
+    background: transparent;
+    border: none;
+    display: block;
+    margin: 0;
+    padding: 30px 20px;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 13px;
+    line-height: 1.6;
+}
+
+.file-list .error-message code {
+    background: var(--bg-primary);
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
 .browser-content {
     display: flex;
     flex: 1;

--- a/tools/build-hvsc-index.js
+++ b/tools/build-hvsc-index.js
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+/*
+ * Builds public/hvsc-index.json — a flat index of every SID in HVSC with
+ * title, author, and released fields parsed from the PSID/RSID header.
+ *
+ * Usage:  node tools/build-hvsc-index.js [--root C64Music] [--concurrency 8]
+ *
+ * The crawler walks directory listings on hvsc.etv.cx and fetches the first
+ * 128 bytes of each .sid via an HTTP Range request so it only pulls the
+ * metadata, not the full file. Expect ~30-60 minutes for a full run.
+ *
+ * Output format (compact keys to keep the file small):
+ *   { v: 1, generated: "2026-...", count: N, entries: [ {p, t, a, r}, ... ] }
+ *     p = path (relative to hvsc root, e.g. "C64Music/MUSICIANS/H/Hubbard_Rob/Commando.sid")
+ *     t = title
+ *     a = author
+ *     r = released
+ */
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+
+const HVSC_ORIGIN = 'https://hvsc.etv.cx';
+const OUTPUT = path.join(__dirname, '..', 'public', 'hvsc-index.json');
+
+const args = parseArgs(process.argv.slice(2));
+const ROOT = args.root || 'C64Music';
+const CONCURRENCY = parseInt(args.concurrency || '8', 10);
+
+function parseArgs(argv) {
+    const out = {};
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a.startsWith('--')) {
+            const key = a.slice(2);
+            const next = argv[i + 1];
+            if (next && !next.startsWith('--')) { out[key] = next; i++; }
+            else { out[key] = true; }
+        }
+    }
+    return out;
+}
+
+function fetchBuffer(url, { headers = {} } = {}) {
+    return new Promise((resolve, reject) => {
+        const req = https.get(url, { headers }, (res) => {
+            if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+                res.resume();
+                resolve(fetchBuffer(new URL(res.headers.location, url).toString(), { headers }));
+                return;
+            }
+            if (res.statusCode !== 200 && res.statusCode !== 206) {
+                res.resume();
+                reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+                return;
+            }
+            const chunks = [];
+            res.on('data', (c) => chunks.push(c));
+            res.on('end', () => resolve(Buffer.concat(chunks)));
+            res.on('error', reject);
+        });
+        req.on('error', reject);
+        req.setTimeout(30000, () => { req.destroy(new Error('Timeout')); });
+    });
+}
+
+async function fetchText(url) {
+    const buf = await fetchBuffer(url);
+    return buf.toString('utf8');
+}
+
+function parseListing(html) {
+    const dirs = [];
+    const files = [];
+    const tableMatch = html.match(/<table[^>]*>([\s\S]*?)<\/table>/i);
+    const scope = tableMatch ? tableMatch[1] : html;
+    const rowRegex = /<a\s+href="([^"]+)"[^>]*>(?:<img[^>]*>)?([^<]+)<\/a>/gi;
+    let m;
+    while ((m = rowRegex.exec(scope)) !== null) {
+        const href = m[1];
+        const text = m[2].trim();
+        if (!text || text === '..' || text === '.' || text === 'Home' ||
+            text === 'About' || text === 'HVSC' || text === 'SidSearch' ||
+            text === 'Parent Directory') continue;
+        if (href.startsWith('http://') || href.startsWith('https://') || href === '#') continue;
+
+        if (href.startsWith('?path=') && !href.includes('info=')) {
+            let p = decodeURIComponent(href.substring(6));
+            if (p.endsWith('/')) p = p.slice(0, -1);
+            dirs.push(p);
+        } else if (href.includes('info=please') && href.includes('.sid')) {
+            const pm = href.match(/path=([^&]+)/);
+            if (pm) files.push(decodeURIComponent(pm[1]));
+        } else if (href.endsWith('.sid')) {
+            // Direct relative .sid link (rare on this mirror, but handle it)
+            files.push(href.replace(/^\//, ''));
+        }
+    }
+    return { dirs: unique(dirs), files: unique(files) };
+}
+
+function unique(arr) { return Array.from(new Set(arr)); }
+
+function readNullString(buf, offset, length) {
+    const end = Math.min(offset + length, buf.length);
+    let s = '';
+    for (let i = offset; i < end; i++) {
+        const b = buf[i];
+        if (b === 0) break;
+        s += String.fromCharCode(b);
+    }
+    return s.trim();
+}
+
+function parseSidHeader(buf) {
+    if (buf.length < 0x76) return null;
+    const magic = buf.toString('ascii', 0, 4);
+    if (magic !== 'PSID' && magic !== 'RSID') return null;
+    return {
+        t: readNullString(buf, 0x16, 32),
+        a: readNullString(buf, 0x36, 32),
+        r: readNullString(buf, 0x56, 32),
+    };
+}
+
+async function fetchSidHeader(sidPath) {
+    const url = `${HVSC_ORIGIN}/${sidPath}`;
+    const buf = await fetchBuffer(url, { headers: { Range: 'bytes=0-127' } });
+    return parseSidHeader(buf);
+}
+
+async function crawl() {
+    const queue = [ROOT];
+    const visited = new Set();
+    const sidPaths = [];
+    let dirCount = 0;
+
+    while (queue.length) {
+        const dir = queue.shift();
+        if (visited.has(dir)) continue;
+        visited.add(dir);
+        dirCount++;
+        try {
+            const html = await fetchText(`${HVSC_ORIGIN}/?path=${encodeURIComponent(dir)}`);
+            const { dirs, files } = parseListing(html);
+            for (const d of dirs) {
+                if (!visited.has(d) && d.startsWith(ROOT)) queue.push(d);
+            }
+            for (const f of files) sidPaths.push(f);
+            if (dirCount % 50 === 0) {
+                process.stderr.write(`  crawled ${dirCount} dirs, ${sidPaths.length} SIDs, ${queue.length} pending\n`);
+            }
+        } catch (err) {
+            process.stderr.write(`  ! dir failed: ${dir} (${err.message})\n`);
+        }
+    }
+
+    return unique(sidPaths);
+}
+
+async function buildIndex(sidPaths) {
+    const entries = [];
+    let done = 0, failed = 0;
+    const total = sidPaths.length;
+
+    async function worker(slice) {
+        for (const p of slice) {
+            try {
+                const meta = await fetchSidHeader(p);
+                if (meta) entries.push({ p, ...meta });
+                else failed++;
+            } catch (err) {
+                failed++;
+            }
+            done++;
+            if (done % 500 === 0) {
+                process.stderr.write(`  headers: ${done}/${total} (failed: ${failed})\n`);
+            }
+        }
+    }
+
+    const slices = Array.from({ length: CONCURRENCY }, () => []);
+    sidPaths.forEach((p, i) => slices[i % CONCURRENCY].push(p));
+    await Promise.all(slices.map(worker));
+
+    entries.sort((a, b) => a.p.localeCompare(b.p));
+    return { entries, failed };
+}
+
+(async function main() {
+    console.error(`Crawling ${HVSC_ORIGIN} starting at ${ROOT} (concurrency=${CONCURRENCY})`);
+    const t0 = Date.now();
+    const sidPaths = await crawl();
+    console.error(`Found ${sidPaths.length} SID files in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+
+    console.error('Fetching SID headers...');
+    const { entries, failed } = await buildIndex(sidPaths);
+    console.error(`Parsed ${entries.length} headers (${failed} failed)`);
+
+    const out = {
+        v: 1,
+        generated: new Date().toISOString(),
+        root: ROOT,
+        count: entries.length,
+        entries,
+    };
+    fs.writeFileSync(OUTPUT, JSON.stringify(out));
+    const mb = (fs.statSync(OUTPUT).size / 1024 / 1024).toFixed(2);
+    console.error(`Wrote ${OUTPUT} (${mb} MB, ${entries.length} entries)`);
+})().catch((err) => {
+    console.error('Fatal:', err);
+    process.exit(1);
+});


### PR DESCRIPTION
HVSC has no search API, so this adds a client-side index: a one-off Node
crawler (tools/build-hvsc-index.js) walks hvsc.etv.cx, fetches only the
first 128 bytes of each SID via HTTP Range requests, and writes
public/hvsc-index.json with {path, title, author, released} per entry.

The HVSC modal now has an always-visible search bar. Typing lazy-loads
the index and filters across the full collection (AND-matching on all
whitespace-separated terms, capped at 500 results). Clearing the box or
navigating via Home/Up/double-click returns to the directory browser.
A missing index is handled gracefully with instructions to run the
builder.

https://claude.ai/code/session_01GvGwKJPqUT3Zs2gFnDXsT9